### PR TITLE
Add -std=g99 flag

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -2,4 +2,4 @@
 
 set filename=recycle-bin
 
-gcc "%filename%".c -municode -O2 -s -o "%filename%".exe
+gcc "%filename%".c -municode -O2 -s -o "%filename%".exe -std=g99


### PR DESCRIPTION
If you have GCC updated to the latest version this shouldn't be an issue but I wouldn't be surprised if people in the Windows world didn't have access to pre-built images of the correct versions...