### PR TITLE
Add support for IFileOperation interface

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -2,4 +2,4 @@
 
 set filename=recycle-bin
 
-gcc "%filename%".c -municode -O2 -s -o "%filename%".exe -std=c99
+gcc "%filename%".c -municode -O2 -lole32 -s -o "%filename%".exe -std=c99

--- a/build.bat
+++ b/build.bat
@@ -2,4 +2,4 @@
 
 set filename=recycle-bin
 
-gcc "%filename%".c -municode -O2 -lole32 -s -o "%filename%".exe -std=c99
+gcc "%filename%".c -municode -O2 -lole32 -luuid -s -o "%filename%".exe -std=c99

--- a/build.bat
+++ b/build.bat
@@ -2,4 +2,4 @@
 
 set filename=recycle-bin
 
-gcc "%filename%".c -municode -O2 -lole32 -luuid -s -o "%filename%".exe -std=c99
+gcc "%filename%".c -municode -O2 -lole32 -luuid -s -o "%filename%".exe -std=c17

--- a/progress.h
+++ b/progress.h
@@ -1,0 +1,189 @@
+#include <initguid.h>
+#include <shlobj.h>
+
+HRESULT STDMETHODCALLTYPE QueryInterface(
+    IFileOperationProgressSink *this,
+    REFIID riid,
+    void **ppv
+) {
+	if (riid == &IID_IUnknown || riid == &IID_IFileOperationProgressSink) {
+		*ppv = this;
+
+		return S_OK;
+	}
+
+	*ppv = NULL;
+
+	return E_NOINTERFACE;
+}
+
+ULONG STDMETHODCALLTYPE AddRef(IFileOperationProgressSink *this) {
+	return S_OK;
+}
+
+ULONG STDMETHODCALLTYPE Release(IFileOperationProgressSink *this) {
+	return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE StartOperations(IFileOperationProgressSink *this) {
+	return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE FinishOperations(
+    IFileOperationProgressSink *this,
+    HRESULT hrResult
+) {
+	return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE PreRenameItem(
+    IFileOperationProgressSink *this,
+    DWORD dwFlags,
+    IShellItem *psiItem,
+    LPCWSTR pszNewName
+) {
+	return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE PostRenameItem(
+    IFileOperationProgressSink *this,
+    DWORD dwFlags,
+    IShellItem *psiItem,
+    LPCWSTR pszNewName,
+    HRESULT hrRename,
+    IShellItem *psiNewlyCreated
+) {
+	return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE PreMoveItem(
+    IFileOperationProgressSink *this,
+    DWORD dwFlags,
+    IShellItem *psiItem,
+    IShellItem *psiDestinationFolder,
+    LPCWSTR pszNewNam
+) {
+	return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE PostMoveItem(
+	IFileOperationProgressSink *this,
+	DWORD dwFlags,
+	IShellItem *psiItem,
+	IShellItem *psiDestinationFolder,
+	LPCWSTR pszNewName,
+	HRESULT hrMove,
+	IShellItem *psiNewlyCreated
+) {
+	return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE PreCopyItem(
+	IFileOperationProgressSink *this,
+	DWORD dwFlags,
+	IShellItem *psiItem,
+	IShellItem *psiDestinationFolder,
+	LPCWSTR pszNewName
+) {
+	return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE PostCopyItem(
+	IFileOperationProgressSink *this,
+	DWORD dwFlags,
+	IShellItem *psiItem,
+	IShellItem *psiDestinationFolder,
+	LPCWSTR pszNewName,
+	HRESULT hrCopy,
+	IShellItem *psiNewlyCreated
+) {
+	return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE PreDeleteItem(
+	IFileOperationProgressSink *this,
+	DWORD dwFlags,
+	IShellItem *psiItem
+) {
+	if (dwFlags & TSF_DELETE_RECYCLE_IF_POSSIBLE) {
+		return S_OK;
+	}
+
+	return E_ABORT;
+}
+
+HRESULT STDMETHODCALLTYPE PostDeleteItem(
+	IFileOperationProgressSink *this,
+	DWORD dwFlags,
+	IShellItem *psiItem,
+	HRESULT hrDelete,
+	IShellItem *psiNewlyCreated
+) {
+	return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE PreNewItem(
+	IFileOperationProgressSink *this,
+	DWORD dwFlags,
+	IShellItem *psiDestinationFolder,
+	LPCWSTR pszNewName
+) {
+	return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE PostNewItem(
+	IFileOperationProgressSink *this,
+	DWORD dwFlags,
+	IShellItem *psiDestinationFolder,
+	LPCWSTR pszNewName,
+	LPCWSTR pszTemplateName,
+	DWORD dwFileAttributes,
+	HRESULT hrNew,
+	IShellItem *psiNewItem
+) {
+	return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE UpdateProgress(
+	IFileOperationProgressSink *this,
+	UINT iWorkTotal,
+	UINT iWorkSoFar
+) {
+	return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE ResetTimer(IFileOperationProgressSink *this) {
+	return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE PauseTimer(IFileOperationProgressSink *this) {
+	return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE ResumeTimer(IFileOperationProgressSink *this) {
+	return S_OK;
+}
+
+static IFileOperationProgressSinkVtbl progressSinkVtbl = {
+	QueryInterface,
+	AddRef,
+	Release,
+	StartOperations,
+	FinishOperations,
+	PreRenameItem,
+	PostRenameItem,
+	PreMoveItem,
+	PostMoveItem,
+	PreCopyItem,
+	PostCopyItem,
+	PreDeleteItem,
+	PostDeleteItem,
+	PreNewItem,
+	PostNewItem,
+	UpdateProgress,
+	ResetTimer,
+	PauseTimer,
+	ResumeTimer
+};
+
+static IFileOperationProgressSink progressSink = { &progressSinkVtbl };

--- a/progress.h
+++ b/progress.h
@@ -2,9 +2,9 @@
 #include <shlobj.h>
 
 HRESULT STDMETHODCALLTYPE QueryInterface(
-    IFileOperationProgressSink *this,
-    REFIID riid,
-    void **ppv
+	IFileOperationProgressSink *this,
+	REFIID riid,
+	void **ppv
 ) {
 	if (riid == &IID_IUnknown || riid == &IID_IFileOperationProgressSink) {
 		*ppv = this;
@@ -30,38 +30,38 @@ HRESULT STDMETHODCALLTYPE StartOperations(IFileOperationProgressSink *this) {
 }
 
 HRESULT STDMETHODCALLTYPE FinishOperations(
-    IFileOperationProgressSink *this,
-    HRESULT hrResult
+	IFileOperationProgressSink *this,
+	HRESULT hrResult
 ) {
 	return S_OK;
 }
 
 HRESULT STDMETHODCALLTYPE PreRenameItem(
-    IFileOperationProgressSink *this,
-    DWORD dwFlags,
-    IShellItem *psiItem,
-    LPCWSTR pszNewName
+	IFileOperationProgressSink *this,
+	DWORD dwFlags,
+	IShellItem *psiItem,
+	LPCWSTR pszNewName
 ) {
 	return S_OK;
 }
 
 HRESULT STDMETHODCALLTYPE PostRenameItem(
-    IFileOperationProgressSink *this,
-    DWORD dwFlags,
-    IShellItem *psiItem,
-    LPCWSTR pszNewName,
-    HRESULT hrRename,
-    IShellItem *psiNewlyCreated
+	IFileOperationProgressSink *this,
+	DWORD dwFlags,
+	IShellItem *psiItem,
+	LPCWSTR pszNewName,
+	HRESULT hrRename,
+	IShellItem *psiNewlyCreated
 ) {
 	return S_OK;
 }
 
 HRESULT STDMETHODCALLTYPE PreMoveItem(
-    IFileOperationProgressSink *this,
-    DWORD dwFlags,
-    IShellItem *psiItem,
-    IShellItem *psiDestinationFolder,
-    LPCWSTR pszNewNam
+	IFileOperationProgressSink *this,
+	DWORD dwFlags,
+	IShellItem *psiItem,
+	IShellItem *psiDestinationFolder,
+	LPCWSTR pszNewNam
 ) {
 	return S_OK;
 }

--- a/recycle-bin.c
+++ b/recycle-bin.c
@@ -20,7 +20,7 @@
 int wmain(int argc, wchar_t **argv) {
 	if (argc == 2) {
 		if (wcscmp(argv[1], L"--version") == 0) {
-			puts("1.0.2");
+			puts("1.0.1");
 			return 0;
 		}
 

--- a/recycle-bin.c
+++ b/recycle-bin.c
@@ -15,84 +15,6 @@
 	return result;\
 }
 
-int delete_files(int count, wchar_t **files) {
-	size_t len = count;
-
-	for (int i = 1; i < count; i++) {
-		len += wcslen(files[i]);
-	}
-
-	wchar_t *from = malloc(len * sizeof(wchar_t));
-
-	int pos = 0;
-
-	for (int i = 1; i < count; i++) {
-		wcscpy(&from[pos], files[i]);
-		pos += wcslen(files[i]) + 1;
-	}
-
-	from[pos] = '\0';
-
-	assert(++pos == len && "position/length mismatch");
-
-	SHFILEOPSTRUCTW op;
-
-	op.hwnd = NULL;
-	op.wFunc = FO_DELETE;
-	op.pFrom = from;
-	op.pTo = NULL;
-	op.fFlags = FOF_ALLOWUNDO | FOF_NO_UI;
-
-	int ret = SHFileOperationW(&op);
-
-	free(from);
-
-	return ret;
-}
-
-int delete_files_new(int count, wchar_t **files) {
-	CHECK(CoInitializeEx(NULL, COINIT_MULTITHREADED));
-
-	IFileOperation *op;
-
-	CHECK(CoCreateInstance(
-		&CLSID_FileOperation,
-		NULL,
-		CLSCTX_ALL,
-		&IID_IFileOperation,
-		(void**)&op
-	));
-
-	CHECK_OBJ(op, op->lpVtbl->SetOperationFlags(
-		op,
-		FOFX_ADDUNDORECORD |
-		FOFX_RECYCLEONDELETE |
-		FOF_NOERRORUI |
-		FOF_SILENT |
-		FOFX_EARLYFAILURE
-	));
-
-	PCIDLIST_ABSOLUTE list[count - 1];
-
-	for (int i = 1; i < count; i++) {
-		for (wchar_t *chr = files[i]; *chr; chr++) {
-			if (*chr == L'/') {
-				*chr = L'\\';
-			}
-		}
-
-		list[i - 1] = ILCreateFromPath(files[i]);
-	}
-
-	IShellItemArray *items;
-
-	CHECK_OBJ(op, SHCreateShellItemArrayFromIDLists(count - 1, list, &items));
-	CHECK_OBJ(op, op->lpVtbl->DeleteItems(op, (IUnknown*)items));
-	CHECK_OBJ(op, op->lpVtbl->PerformOperations(op));
-
-	return op->lpVtbl->Release(op);
-}
-
 int wmain(int argc, wchar_t **argv) {
 	if (argc == 2) {
 		if (wcscmp(argv[1], L"--version") == 0) {
@@ -109,9 +31,60 @@ int wmain(int argc, wchar_t **argv) {
 		return 1;
 	}
 
+	int count = argc - 1;
+	wchar_t **files = argv + 1;
+
+	CHECK(CoInitializeEx(NULL, COINIT_MULTITHREADED));
+
+	IFileOperation *op;
+
+	CHECK(CoCreateInstance(
+		&CLSID_FileOperation,
+		NULL,
+		CLSCTX_ALL,
+		&IID_IFileOperation,
+		(void**)&op
+	));
+
 	if (IsWindows8OrGreater()) {
-		return delete_files_new(argc, argv);
+		CHECK_OBJ(op, op->lpVtbl->SetOperationFlags(
+			op,
+			FOFX_ADDUNDORECORD |
+			FOFX_RECYCLEONDELETE |
+			FOF_NOERRORUI |
+			FOF_SILENT |
+			FOFX_EARLYFAILURE
+		));
+	} else {
+		CHECK_OBJ(op, op->lpVtbl->SetOperationFlags(
+			op,
+			FOF_NO_UI |
+			FOF_ALLOWUNDO |
+			FOF_NOERRORUI |
+			FOF_SILENT |
+			FOFX_EARLYFAILURE
+		));
 	}
 
-	return delete_files(argc, argv);
+	PCIDLIST_ABSOLUTE list[count];
+
+	for (int i = 0; i < count; i++) {
+		for (wchar_t *chr = files[i]; *chr; chr++) {
+			if (*chr == L'/') {
+				*chr = L'\\';
+			}
+		}
+
+		IShellItem *item;
+
+		list[i] = ILCreateFromPath(files[i]);
+	}
+
+	IShellItemArray *items;
+
+	CHECK_OBJ(op, SHCreateShellItemArrayFromIDLists(count, list, &items));
+	CHECK_OBJ(op, op->lpVtbl->DeleteItems(op, (IUnknown*)items));
+	CHECK_OBJ(op, op->lpVtbl->PerformOperations(op));
+
+	return op->lpVtbl->Release(op);
 }

--- a/recycle-bin.c
+++ b/recycle-bin.c
@@ -70,16 +70,16 @@ int wmain(int argc, wchar_t **argv) {
 
 	for (int i = 0; i < count; i++) {
 		int len = GetFullPathName(files[i], 0, NULL, NULL);
-		wchar_t *buf = malloc((len + 1) * sizeof(wchar_t));
 
-		if (GetFullPathName(files[i], len, buf, NULL) == 0) {
+		if (len == 0) {
 			op->lpVtbl->Release(op);
 
-			return -1;
+			return 1;
 		}
 
-		IShellItem *item;
+		wchar_t *buf = malloc((len + 1) * sizeof(wchar_t));
 
+		GetFullPathName(files[i], len, buf, NULL);
 		list[i] = ILCreateFromPath(buf);
 
 		free(buf);
@@ -90,10 +90,6 @@ int wmain(int argc, wchar_t **argv) {
 	CHECK_OBJ(op, SHCreateShellItemArrayFromIDLists(count, list, &items));
 	CHECK_OBJ(op, op->lpVtbl->DeleteItems(op, (IUnknown*)items));
 	CHECK_OBJ(op, op->lpVtbl->PerformOperations(op));
-
-	for (int i = 0; i < count; i++) {
-		ILFree(list[i]);
-	}
 
 	return op->lpVtbl->Release(op);
 }

--- a/recycle-bin.c
+++ b/recycle-bin.c
@@ -1,38 +1,34 @@
+#define _WIN32_IE _WIN32_IE_IE70
+
 #include <stdio.h>
 #include <windows.h>
 #include <assert.h>
+#include <versionhelpers.h>
+#include <initguid.h>
+#include <shlobj.h>
 
-int wmain(int argc, wchar_t **argv) {
-	if (argc == 2) {
-		if (wcscmp(argv[1], L"--version") == 0) {
-			puts("1.0.1");
-			return 0;
-		}
+#define CHECK(result) if (FAILED(result)) {\
+	return result;\
+}
+#define CHECK_OBJ(obj, result) if (FAILED(result)) {\
+	obj->lpVtbl->Release(obj);\
+	return result;\
+}
 
-		if (wcscmp(argv[1], L"--help") == 0) {
-			puts("\n  Move files and folders to the recycle bin\n\n  Usage: recycle-bin <path> [...]\n\n  Created by Sindre Sorhus");
-			return 0;
-		}
-	}
+int delete_files(int count, wchar_t **files) {
+	size_t len = count;
 
-	if (argc == 1) {
-		puts("Specify at least one path");
-		return 1;
-	}
-
-	size_t len = argc;
-
-	for (int i = 1; i < argc; i++) {
-		len += wcslen(argv[i]);
+	for (int i = 1; i < count; i++) {
+		len += wcslen(files[i]);
 	}
 
 	wchar_t *from = malloc(len * sizeof(wchar_t));
 
 	int pos = 0;
 
-	for (int i = 1; i < argc; i++) {
-		wcscpy(&from[pos], argv[i]);
-		pos += wcslen(argv[i]) + 1;
+	for (int i = 1; i < count; i++) {
+		wcscpy(&from[pos], files[i]);
+		pos += wcslen(files[i]) + 1;
 	}
 
 	from[pos] = '\0';
@@ -52,4 +48,70 @@ int wmain(int argc, wchar_t **argv) {
 	free(from);
 
 	return ret;
+}
+
+int delete_files_new(int count, wchar_t **files) {
+	CHECK(CoInitializeEx(NULL, COINIT_MULTITHREADED));
+
+	IFileOperation *op;
+
+	CHECK(CoCreateInstance(
+		&CLSID_FileOperation,
+		NULL,
+		CLSCTX_ALL,
+		&IID_IFileOperation,
+		(void**)&op
+	));
+
+	CHECK_OBJ(op, op->lpVtbl->SetOperationFlags(
+		op,
+		FOFX_ADDUNDORECORD |
+		FOFX_RECYCLEONDELETE |
+		FOF_NOERRORUI |
+		FOF_SILENT |
+		FOFX_EARLYFAILURE
+	));
+
+	PCIDLIST_ABSOLUTE list[count - 1];
+
+	for (int i = 1; i < count; i++) {
+		for (wchar_t *chr = files[i]; *chr; chr++) {
+			if (*chr == L'/') {
+				*chr = L'\\';
+			}
+		}
+
+		list[i - 1] = ILCreateFromPath(files[i]);
+	}
+
+	IShellItemArray *items;
+
+	CHECK_OBJ(op, SHCreateShellItemArrayFromIDLists(count - 1, list, &items));
+	CHECK_OBJ(op, op->lpVtbl->DeleteItems(op, (IUnknown*)items));
+	CHECK_OBJ(op, op->lpVtbl->PerformOperations(op));
+
+	return op->lpVtbl->Release(op);
+}
+
+int wmain(int argc, wchar_t **argv) {
+	if (argc == 2) {
+		if (wcscmp(argv[1], L"--version") == 0) {
+			puts("1.0.2");
+			return 0;
+		}
+
+		if (wcscmp(argv[1], L"--help") == 0) {
+			puts("\n  Move files and folders to the recycle bin\n\n  Usage: recycle-bin <path> [...]\n\n  Created by Sindre Sorhus");
+			return 0;
+		}
+	} else if (argc == 1) {
+		puts("Specify at least one path");
+		return 1;
+	}
+
+	if (IsWindows8OrGreater()) {
+		return delete_files_new(argc, argv);
+	}
+
+	return delete_files(argc, argv);
 }

--- a/recycle-bin.c
+++ b/recycle-bin.c
@@ -36,7 +36,7 @@ int wmain(int argc, wchar_t **argv) {
 	int count = argc - 1;
 	wchar_t **files = argv + 1;
 
-	CHECK(CoInitializeEx(NULL, COINIT_MULTITHREADED));
+	CHECK(CoInitializeEx(NULL, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE));
 
 	IFileOperation *op;
 

--- a/recycle-bin.c
+++ b/recycle-bin.c
@@ -1,12 +1,13 @@
 #define _WIN32_IE _WIN32_IE_IE70
 
+#include "progress.h"
+
 #include <stdio.h>
 #include <windows.h>
 #include <assert.h>
 #include <versionhelpers.h>
 #include <initguid.h>
 #include <shlobj.h>
-#include <unknwn.h>
 
 #define CHECK(result) if (FAILED(result)) {\
 	return result;\
@@ -15,172 +16,6 @@
 	obj->lpVtbl->Release(obj);\
 	return result;\
 }
-
-HRESULT STDMETHODCALLTYPE QueryInterface(IFileOperationProgressSink *this, REFIID riid, void **ppv) {
-	if (IsEqualIID(riid, &IID_IUnknown) || IsEqualIID(riid, &IID_IFileOperationProgressSink)) {
-		*ppv = this;
-
-		return S_OK;
-	}
-
-	*ppv = NULL;
-
-	return E_NOINTERFACE;
-}
-
-ULONG STDMETHODCALLTYPE AddRef(IFileOperationProgressSink *this) {
-	return S_OK;
-}
-
-ULONG STDMETHODCALLTYPE Release(IFileOperationProgressSink *this) {
-	return S_OK;
-}
-
-HRESULT STDMETHODCALLTYPE StartOperations(IFileOperationProgressSink *this) {
-	return S_OK;
-}
-
-HRESULT STDMETHODCALLTYPE FinishOperations(IFileOperationProgressSink *this, HRESULT hrResult) {
-	return S_OK;
-}
-
-HRESULT STDMETHODCALLTYPE PreRenameItem(IFileOperationProgressSink *this, DWORD dwFlags, IShellItem *psiItem, LPCWSTR pszNewName) {
-	return S_OK;
-}
-
-HRESULT STDMETHODCALLTYPE PostRenameItem(IFileOperationProgressSink *this, DWORD dwFlags, IShellItem *psiItem, LPCWSTR pszNewName, HRESULT hrRename, IShellItem *psiNewlyCreated) {
-	return S_OK;
-}
-
-HRESULT STDMETHODCALLTYPE PreMoveItem(IFileOperationProgressSink *this, DWORD dwFlags, IShellItem *psiItem, IShellItem *psiDestinationFolder, LPCWSTR pszNewName) {
-	return S_OK;
-}
-
-HRESULT STDMETHODCALLTYPE PostMoveItem(
-	IFileOperationProgressSink *this,
-	DWORD dwFlags,
-	IShellItem *psiItem,
-	IShellItem *psiDestinationFolder,
-	LPCWSTR pszNewName,
-	HRESULT hrMove,
-	IShellItem *psiNewlyCreated
-) {
-	return S_OK;
-}
-
-HRESULT STDMETHODCALLTYPE PreCopyItem(
-	IFileOperationProgressSink *this,
-	DWORD dwFlags,
-	IShellItem *psiItem,
-	IShellItem *psiDestinationFolder,
-	LPCWSTR pszNewName
-) {
-	return S_OK;
-}
-
-HRESULT STDMETHODCALLTYPE PostCopyItem(
-	IFileOperationProgressSink *this,
-	DWORD dwFlags,
-	IShellItem *psiItem,
-	IShellItem *psiDestinationFolder,
-	LPCWSTR pszNewName,
-	HRESULT hrCopy,
-	IShellItem *psiNewlyCreated
-) {
-	return S_OK;
-}
-
-HRESULT STDMETHODCALLTYPE PreDeleteItem(
-	IFileOperationProgressSink *this,
-	DWORD dwFlags,
-	IShellItem *psiItem
-) {
-	if (dwFlags & TSF_DELETE_RECYCLE_IF_POSSIBLE) {
-		return S_OK;
-	}
-
-	return E_ABORT;
-}
-
-HRESULT STDMETHODCALLTYPE PostDeleteItem(
-	IFileOperationProgressSink *this,
-	DWORD dwFlags,
-	IShellItem *psiItem,
-	HRESULT hrDelete,
-	IShellItem *psiNewlyCreated
-) {
-	return S_OK;
-}
-
-HRESULT STDMETHODCALLTYPE PreNewItem(
-	IFileOperationProgressSink *this,
-	DWORD dwFlags,
-	IShellItem *psiDestinationFolder,
-	LPCWSTR pszNewName
-) {
-	return S_OK;
-}
-
-HRESULT STDMETHODCALLTYPE PostNewItem(
-	IFileOperationProgressSink *this,
-	DWORD dwFlags,
-	IShellItem *psiDestinationFolder,
-	LPCWSTR pszNewName,
-	LPCWSTR pszTemplateName,
-	DWORD dwFileAttributes,
-	HRESULT hrNew,
-	IShellItem *psiNewItem
-) {
-	return S_OK;
-}
-
-HRESULT STDMETHODCALLTYPE UpdateProgress(
-	IFileOperationProgressSink *this,
-	UINT iWorkTotal,
-	UINT iWorkSoFar
-) {
-	return S_OK;
-}
-
-HRESULT STDMETHODCALLTYPE ResetTimer(
-	IFileOperationProgressSink *this
-) {
-	return S_OK;
-}
-
-HRESULT STDMETHODCALLTYPE PauseTimer(
-	IFileOperationProgressSink *this
-) {
-	return S_OK;
-}
-
-HRESULT STDMETHODCALLTYPE ResumeTimer(
-	IFileOperationProgressSink *this
-) {
-	return S_OK;
-}
-
-static IFileOperationProgressSinkVtbl IFileOperationProgressSink_Vtbl = {
-	QueryInterface,
-	AddRef,
-	Release,
-	StartOperations,
-	FinishOperations,
-	PreRenameItem,
-	PostRenameItem,
-	PreMoveItem,
-	PostMoveItem,
-	PreCopyItem,
-	PostCopyItem,
-	PreDeleteItem,
-	PostDeleteItem,
-	PreNewItem,
-	PostNewItem,
-	UpdateProgress,
-	ResetTimer,
-	PauseTimer,
-	ResumeTimer
-};
 
 int wmain(int argc, wchar_t **argv) {
 	if (argc == 2) {
@@ -254,13 +89,10 @@ int wmain(int argc, wchar_t **argv) {
 	}
 
 	IShellItemArray *items;
-
-	IFileOperationProgressSink *progressSink = (IFileOperationProgressSink*)GlobalAlloc(GMEM_FIXED, sizeof(IFileOperationProgressSink));
 	DWORD cookie;
-	progressSink->lpVtbl = &IFileOperationProgressSink_Vtbl;
 
-	CHECK_OBJ(op, op->lpVtbl->Advise(op, progressSink, &cookie));
 	CHECK_OBJ(op, SHCreateShellItemArrayFromIDLists(count, list, &items));
+	CHECK_OBJ(op, op->lpVtbl->Advise(op, &progressSink, &cookie));
 	CHECK_OBJ(op, op->lpVtbl->DeleteItems(op, (IUnknown*)items));
 	CHECK_OBJ(op, op->lpVtbl->PerformOperations(op));
 

--- a/recycle-bin.c
+++ b/recycle-bin.c
@@ -6,6 +6,7 @@
 #include <versionhelpers.h>
 #include <initguid.h>
 #include <shlobj.h>
+#include <unknwn.h>
 
 #define CHECK(result) if (FAILED(result)) {\
 	return result;\
@@ -14,6 +15,172 @@
 	obj->lpVtbl->Release(obj);\
 	return result;\
 }
+
+HRESULT STDMETHODCALLTYPE QueryInterface(IFileOperationProgressSink *this, REFIID riid, void **ppv) {
+	if (IsEqualIID(riid, &IID_IUnknown) || IsEqualIID(riid, &IID_IFileOperationProgressSink)) {
+		*ppv = this;
+
+		return S_OK;
+	}
+
+	*ppv = NULL;
+
+	return E_NOINTERFACE;
+}
+
+ULONG STDMETHODCALLTYPE AddRef(IFileOperationProgressSink *this) {
+	return S_OK;
+}
+
+ULONG STDMETHODCALLTYPE Release(IFileOperationProgressSink *this) {
+	return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE StartOperations(IFileOperationProgressSink *this) {
+	return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE FinishOperations(IFileOperationProgressSink *this, HRESULT hrResult) {
+	return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE PreRenameItem(IFileOperationProgressSink *this, DWORD dwFlags, IShellItem *psiItem, LPCWSTR pszNewName) {
+	return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE PostRenameItem(IFileOperationProgressSink *this, DWORD dwFlags, IShellItem *psiItem, LPCWSTR pszNewName, HRESULT hrRename, IShellItem *psiNewlyCreated) {
+	return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE PreMoveItem(IFileOperationProgressSink *this, DWORD dwFlags, IShellItem *psiItem, IShellItem *psiDestinationFolder, LPCWSTR pszNewName) {
+	return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE PostMoveItem(
+	IFileOperationProgressSink *this,
+	DWORD dwFlags,
+	IShellItem *psiItem,
+	IShellItem *psiDestinationFolder,
+	LPCWSTR pszNewName,
+	HRESULT hrMove,
+	IShellItem *psiNewlyCreated
+) {
+	return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE PreCopyItem(
+	IFileOperationProgressSink *this,
+	DWORD dwFlags,
+	IShellItem *psiItem,
+	IShellItem *psiDestinationFolder,
+	LPCWSTR pszNewName
+) {
+	return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE PostCopyItem(
+	IFileOperationProgressSink *this,
+	DWORD dwFlags,
+	IShellItem *psiItem,
+	IShellItem *psiDestinationFolder,
+	LPCWSTR pszNewName,
+	HRESULT hrCopy,
+	IShellItem *psiNewlyCreated
+) {
+	return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE PreDeleteItem(
+	IFileOperationProgressSink *this,
+	DWORD dwFlags,
+	IShellItem *psiItem
+) {
+	if (dwFlags & TSF_DELETE_RECYCLE_IF_POSSIBLE) {
+		return S_OK;
+	}
+
+	return E_ABORT;
+}
+
+HRESULT STDMETHODCALLTYPE PostDeleteItem(
+	IFileOperationProgressSink *this,
+	DWORD dwFlags,
+	IShellItem *psiItem,
+	HRESULT hrDelete,
+	IShellItem *psiNewlyCreated
+) {
+	return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE PreNewItem(
+	IFileOperationProgressSink *this,
+	DWORD dwFlags,
+	IShellItem *psiDestinationFolder,
+	LPCWSTR pszNewName
+) {
+	return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE PostNewItem(
+	IFileOperationProgressSink *this,
+	DWORD dwFlags,
+	IShellItem *psiDestinationFolder,
+	LPCWSTR pszNewName,
+	LPCWSTR pszTemplateName,
+	DWORD dwFileAttributes,
+	HRESULT hrNew,
+	IShellItem *psiNewItem
+) {
+	return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE UpdateProgress(
+	IFileOperationProgressSink *this,
+	UINT iWorkTotal,
+	UINT iWorkSoFar
+) {
+	return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE ResetTimer(
+	IFileOperationProgressSink *this
+) {
+	return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE PauseTimer(
+	IFileOperationProgressSink *this
+) {
+	return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE ResumeTimer(
+	IFileOperationProgressSink *this
+) {
+	return S_OK;
+}
+
+static IFileOperationProgressSinkVtbl IFileOperationProgressSink_Vtbl = {
+	QueryInterface,
+	AddRef,
+	Release,
+	StartOperations,
+	FinishOperations,
+	PreRenameItem,
+	PostRenameItem,
+	PreMoveItem,
+	PostMoveItem,
+	PreCopyItem,
+	PostCopyItem,
+	PreDeleteItem,
+	PostDeleteItem,
+	PreNewItem,
+	PostNewItem,
+	UpdateProgress,
+	ResetTimer,
+	PauseTimer,
+	ResumeTimer
+};
 
 int wmain(int argc, wchar_t **argv) {
 	if (argc == 2) {
@@ -52,6 +219,7 @@ int wmain(int argc, wchar_t **argv) {
 			FOFX_ADDUNDORECORD |
 			FOFX_RECYCLEONDELETE |
 			FOF_NOERRORUI |
+			FOF_NOCONFIRMATION |
 			FOF_SILENT |
 			FOFX_EARLYFAILURE
 		));
@@ -87,6 +255,11 @@ int wmain(int argc, wchar_t **argv) {
 
 	IShellItemArray *items;
 
+	IFileOperationProgressSink *progressSink = (IFileOperationProgressSink*)GlobalAlloc(GMEM_FIXED, sizeof(IFileOperationProgressSink));
+	DWORD cookie;
+	progressSink->lpVtbl = &IFileOperationProgressSink_Vtbl;
+
+	CHECK_OBJ(op, op->lpVtbl->Advise(op, progressSink, &cookie));
 	CHECK_OBJ(op, SHCreateShellItemArrayFromIDLists(count, list, &items));
 	CHECK_OBJ(op, op->lpVtbl->DeleteItems(op, (IUnknown*)items));
 	CHECK_OBJ(op, op->lpVtbl->PerformOperations(op));

--- a/test.bat
+++ b/test.bat
@@ -1,0 +1,55 @@
+@echo off
+
+setlocal enabledelayedexpansion
+
+:: Global settings
+set program=recycle-bin
+set dir=test
+set name=a
+
+:: Test cases
+<nul set /p="Test case #1: Long directory names: "
+call :test 100 5
+
+<nul set /p="Test case #2: Deep folder hierarchy: "
+call :test 20 20
+
+<nul set /p="Test case #3: Deep hierarchy with long paths: "
+call :test 200 20
+
+exit /b
+
+:: Test case procedure
+:: Parameters: <filename-length> <hierarchy-depth>
+:test
+    :: Repeat filename
+    set file=
+    for /l %%i in (1, 1, %~1) do set file=!file!%name%
+
+    :: Create initial directory
+    set target=%dir%
+    mkdir %target%
+
+    :: Create folder hierarchy
+    for /l %%i in (1, 1, %~2) do (
+        set target=!target!\%file%
+        mkdir %file%
+        robocopy %file% !target! /MOVE >nul
+    )
+
+    :: Delete long path
+    "%program%".exe !target!
+
+    if %errorlevel% == 0 (
+        if exist !target! (
+            echo FAILED
+        ) else (
+            echo PASSED
+        )
+    ) else (
+        echo FAILED
+    )
+
+    :: Clean up
+    "%program%".exe %dir%
+goto :eof


### PR DESCRIPTION
I've managed to implement support for the `IFileOperation` interface in pure C 😃. Right now, the program falls back to the old `SHFileOperation` function for versions lower than Windows 8, but I think we should remove support for the old API altogether, as recycle on delete is the default behavior with `IFileOperation` for Windows 7 and Vista, according to [Electron](https://github.com/electron/electron/blob/master/atom/common/platform_util_win.cc#L345). Dealing with `COM interfaces` in C/C++ is a little bit ugly in general, so I've added some [macros](https://github.com/medusalix/recycle-bin/blob/e495371c08d7921e126ab19e8c49742413e40599/recycle-bin.c#L10-L16) to help with error checking. Not sure if that's the best way to do so, open for improvements.

I added some comments for stuff that requires a little explanation to understand.

Resolves #1
